### PR TITLE
공용 버튼 컴포넌트의 text variant  추가

### DIFF
--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -17,6 +17,7 @@ const buttonVariants = cva(
         rounded:
           'px-9.5 py-3 rounded-12 bg-primary disabled:bg-gray-100 active:bg-tertiary hover:bg-primary',
         icon: 'p-2 rounded-2 hover:bg-gray-100/40 text-black disabled:text-gray-400',
+        text: 'p-2.5 rounded-2 bg-transparent hover:bg-gray-100/40 text-black disabled:text-gray-400',
       },
     },
     defaultVariants: {

--- a/stories/Button.stories.tsx
+++ b/stories/Button.stories.tsx
@@ -87,3 +87,20 @@ export const Icon: Story = {
     </div>
   ),
 };
+
+export const Text: Story = {
+  args: {
+    variant: 'text',
+  },
+  render: (args) => (
+    <div
+      style={{
+        display: 'flex',
+        gap: '1rem',
+      }}
+    >
+      <Button {...args} />
+      <Button {...args} disabled />
+    </div>
+  ),
+};


### PR DESCRIPTION
## 공용 버튼 컴포넌트의 text variant  추가

텍스트 버튼이 없어서 추가하는 것이 좋을 것 같습니다
헤더의 버튼들이나 요약본 상세 페이지의 [수정], [삭제] 버튼 등에 사용될 것 같습니다