### PR TITLE
fix: useSearchParams를 사용하는 컴포넌트를 Suspense로 감싸기

### DIFF
--- a/app/oauth/kakao/callback/page.tsx
+++ b/app/oauth/kakao/callback/page.tsx
@@ -1,6 +1,10 @@
 import Callback from '@/app/oauth/kakao/callback/kakao-callback-client';
-import React from 'react';
+import React, { Suspense } from 'react';
 
 export default function KaKaoCallbackClient() {
-  return <Callback />;
+  return (
+    <Suspense>
+      <Callback />
+    </Suspense>
+  );
 }

--- a/components/header/main-header.tsx
+++ b/components/header/main-header.tsx
@@ -5,7 +5,7 @@ import TextButton from '@/components/ui/TextButton';
 import UserButton from '@/components/user/user-button';
 import { useUserProfile } from '@/lib/service/user/use-user-service';
 import Link from 'next/link';
-import { FunctionComponent } from 'react';
+import { FunctionComponent, Suspense } from 'react';
 
 const MainHeader: FunctionComponent = () => {
   const userQuery = useUserProfile();
@@ -33,7 +33,9 @@ const MainHeader: FunctionComponent = () => {
             <DialogTrigger asChild>
               <TextButton>로그인</TextButton>
             </DialogTrigger>
-            <LoginDialog />
+            <Suspense>
+              <LoginDialog />
+            </Suspense>
           </Dialog>
         </nav>
       </div>


### PR DESCRIPTION
useSearchParams를 사용하는 KaKaoCallbackClient, MainHeader를 Suspense로 래핑

