### PR TITLE
fix: 한글 입력 후 엔터키 입력 시 마지막 글자만 있는 태그가 추가로 생성되는 이슈 해결

### DIFF
--- a/components/post/post-tags.tsx
+++ b/components/post/post-tags.tsx
@@ -1,7 +1,9 @@
+'use client';
 import Chip from '@/components/ui/Chip';
 import React, {
   ChangeEvent,
   forwardRef,
+  KeyboardEvent,
   useImperativeHandle,
   useState,
 } from 'react';
@@ -36,6 +38,12 @@ const PostTags = forwardRef<{ getTagList: () => string[] }, PostTagsProps>(
       setTagList([...tagList, tag]);
       setTag('');
     };
+    const handleKeyUp = (e: KeyboardEvent<HTMLInputElement>) => {
+      // e.isComposing이 true이면 IME 입력 중이므로, 이벤트를 무시합니다.
+      if (e.key === 'Enter') {
+        addNewTag();
+      }
+    };
 
     useImperativeHandle(ref, () => ({
       getTagList: () => tagList,
@@ -53,7 +61,7 @@ const PostTags = forwardRef<{ getTagList: () => string[] }, PostTagsProps>(
             type="text"
             placeholder="태그를 입력하세요"
             value={tag}
-            onKeyDown={(e) => e.key === 'Enter' && addNewTag()}
+            onKeyUp={handleKeyUp}
             onChange={handleTagChange}
             onBlur={addNewTag}
             className="px-2 py-1"


### PR DESCRIPTION
Fixes: #56
- 원인 : IME 입력이 완료되지 않은 상태에서 onKeyDown 이벤트가 발생하여 입력 도중에 엔터를 누르면 두 번 수행됨
- 해결 : 키가 눌린 후에 발생하는 onKeyUp 으로 변경하여 IME 입력이 완료된 상태에서 Enter key 처리