### PR TITLE
feat: input 컴포넌트의 aria-valid 상태로 에러 테두리 표시

### DIFF
--- a/components/ui/Input.tsx
+++ b/components/ui/Input.tsx
@@ -5,7 +5,7 @@ import { typography } from '@/styles/typography';
 import { cva, VariantProps } from 'class-variance-authority';
 
 const inputVariants = cva(
-  'ring-tertiary peer placeholder:tracking-normal placeholder:font-regular flex w-full rounded-2 bg-white shadow-inner shadow-gray-400 ring-offset-2  placeholder:text-gray-200 hover:shadow-primary-200 focus-visible:outline-none focus-visible:ring-2 disabled:cursor-not-allowed disabled:bg-gray-50 disabled:shadow-gray-200',
+  'ring-tertiary peer placeholder:tracking-normal placeholder:font-regular flex w-full rounded-2 bg-white shadow-inner shadow-gray-400 ring-offset-2  placeholder:text-gray-200 hover:shadow-primary-200 focus-visible:outline-none focus-visible:ring-2 disabled:cursor-not-allowed disabled:bg-gray-50 disabled:shadow-gray-200 aria-invalid:shadow-error-400',
   {
     variants: {
       size: {

--- a/stories/Input.stories.tsx
+++ b/stories/Input.stories.tsx
@@ -40,6 +40,9 @@ const meta: Meta<typeof Input> = {
     disabled: {
       control: { type: 'boolean' },
     },
+    'aria-invalid': {
+      control: { type: 'boolean' },
+    },
   },
   tags: ['autodocs'],
 } satisfies Meta<typeof Input>;
@@ -116,7 +119,7 @@ export const WithErrorMessage: Story = {
       }}
     >
       <Label htmlFor="error-message">라벨</Label>
-      <Input {...args} id="error-message" />
+      <Input {...args} id="error-message" aria-invalid="true" />
       <ErrorMessage>에러 메시지입니다.</ErrorMessage>
     </div>
   ),

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -35,6 +35,9 @@ const config: Config = {
     colors: color,
     extend: {
       boxShadow: boxShadow,
+      aria: {
+        invalid: 'invalid="true"',
+      },
     },
   },
 };


### PR DESCRIPTION
` <Input aria-invalid="true" />` aria-invalid 값이 "true" 일 때 테두리가 에러 색상으로 표시됨