### PR TITLE
게시물 상세보기 페이지 관련 이슈 수정

### DIFF
--- a/app/posts/[id]/page.tsx
+++ b/app/posts/[id]/page.tsx
@@ -8,15 +8,13 @@ function PostsPage({ params }: { params: { id: string } }) {
 
   return (
     <>
-      <div className="mx-auto flex w-full max-w-[960px] flex-col gap-7">
-        <Suspense fallback={<div>Loading...</div>}>
-          <PrefetchBoundary
-            fetchQueryOptions={postQuerys.detail({ id, status: 'published' })}
-          >
-            <PostDetail id={id} readOnly={true} status="published" />
-          </PrefetchBoundary>
-        </Suspense>
-      </div>
+      <Suspense fallback={<div>Loading...</div>}>
+        <PrefetchBoundary
+          fetchQueryOptions={postQuerys.detail({ id, status: 'published' })}
+        >
+          <PostDetail id={id} readOnly={true} status="published" />
+        </PrefetchBoundary>
+      </Suspense>
     </>
   );
 }

--- a/app/result/[id]/page.tsx
+++ b/app/result/[id]/page.tsx
@@ -10,7 +10,7 @@ function ResultPage({ params }: { params: { id: string } }) {
 
   return (
     <>
-      <div className="mx-auto flex flex-1 flex-col">
+      <div className="mx-auto flex max-w-[960px] flex-col">
         <Suspense fallback={<div>Loading...</div>}>
           <PrefetchBoundary
             fetchQueryOptions={postQuerys.detail({ id, status: 'draft' })}

--- a/app/result/[id]/page.tsx
+++ b/app/result/[id]/page.tsx
@@ -10,7 +10,7 @@ function ResultPage({ params }: { params: { id: string } }) {
 
   return (
     <>
-      <div className="mx-auto flex max-w-[960px] flex-1 flex-col">
+      <div className="mx-auto flex flex-1 flex-col">
         <Suspense fallback={<div>Loading...</div>}>
           <PrefetchBoundary
             fetchQueryOptions={postQuerys.detail({ id, status: 'draft' })}

--- a/components/post/post-detail.tsx
+++ b/components/post/post-detail.tsx
@@ -37,7 +37,7 @@ const PostDetail: FunctionComponent<PostDetailProps> = ({
   const isPublished = status === 'published';
 
   return (
-    <div className="mx-auto w-full max-w-[960px] flex-1">
+    <div className="mx-auto w-full max-w-[960px]">
       {isPublished && (
         <Link
           href={`/archive/${archiveId}`}

--- a/components/post/post-detail.tsx
+++ b/components/post/post-detail.tsx
@@ -22,13 +22,30 @@ const PostDetail: FunctionComponent<PostDetailProps> = ({
   readOnly,
 }) => {
   const {
-    data: { content, url, title, memoContent, memoCreatedAt, tagList },
+    data: {
+      archiveId,
+      archiveName,
+      content,
+      url,
+      title,
+      memoContent,
+      memoCreatedAt,
+      tagList,
+    },
   } = usePostDetail({ id, status });
 
   const isPublished = status === 'published';
 
   return (
-    <div className="mx-auto flex-1">
+    <div className="mx-auto w-full max-w-[960px] flex-1">
+      {isPublished && (
+        <Link
+          href={`/archive/${archiveId}`}
+          className={cn(typography({ scale: 'body-2' }))}
+        >
+          {archiveName}
+        </Link>
+      )}
       <PostTitle initialTitle={title} readOnly />
       {isPublished && (
         <div className="flex h-15 items-center justify-end">

--- a/components/post/post-editor.tsx
+++ b/components/post/post-editor.tsx
@@ -24,7 +24,7 @@ interface PostEditorProps {
 
 const PostEditor: FunctionComponent<PostEditorProps> = ({ id, status }) => {
   const {
-    data: { content, title, tagList },
+    data: { content, title, tagList, archiveId },
   } = usePostDetail({ id, status });
   const { mutate: updatePostMutate } = useUpdatePostMutation();
   const titleRef = useRef<{ getTitle: () => string }>(null);
@@ -113,7 +113,10 @@ const PostEditor: FunctionComponent<PostEditorProps> = ({ id, status }) => {
                     저장하기
                   </Button>
                 </DialogTrigger>
-                <SavePostDialog onSubmit={updatePost} />
+                <SavePostDialog
+                  onSubmit={updatePost}
+                  initialArchiveId={archiveId}
+                />
               </Dialog>
             </div>
           </div>

--- a/types/post-types.ts
+++ b/types/post-types.ts
@@ -8,8 +8,10 @@ export interface Post {
   url: string;
   tagList: string[];
   createdAt: string;
-  memoContent: string;
-  memoCreatedAt: string;
+  archiveId?: number;
+  archiveName?: string;
+  memoContent?: string;
+  memoCreatedAt?: string;
 }
 
 export interface CreatePostRequest {


### PR DESCRIPTION
- 게시글 수정 시 속한 아카이브가 기본 선택되도록 수정하였습니다 Fixes #63 
- 게시글 상세보기 시 속한 아카이브 이름이 표시되고 클릭 시 이동하도록 하였습니다 Fixes #65 
- 로딩 중에 게시글 레이아웃이 작은 이슈 수정하였습니다