### PR TITLE
fix: 메인 페이지의 로고에 대해 최적화를 사용하지 않도록 img 태그로 변경

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,5 @@
+/* eslint-disable @next/next/no-img-element */
 import URLTextField from '@/components/post/url-text-field';
-import Image from 'next/image';
 import React from 'react';
 export default function Home() {
   return (
@@ -7,7 +7,7 @@ export default function Home() {
       <div className="h-17 bg-white" />
       <div className="p relative bg-primary-400">
         <div className="z-1 absolute bottom-0 h-[8.8%] w-full bg-white"></div>
-        <Image
+        <img
           src="/main_logo.png"
           alt="main-logo"
           width={1064}


### PR DESCRIPTION
#51

이미지 최적화 해제를 위해 `<Image>` -> `<img>` 태그로 변경