### PR TITLE
query client의 retry 옵션 false로 변경

### DIFF
--- a/components/utils/Providers.tsx
+++ b/components/utils/Providers.tsx
@@ -14,6 +14,10 @@ function makeQueryClient() {
         // With SSR, we usually want to set some default staleTime
         // above 0 to avoid refetching immediately on the client
         staleTime: 60 * 1000,
+        retry: false,
+      },
+      mutations: {
+        retry: false,
       },
     },
   });


### PR DESCRIPTION
#76 

3번이나 재시도할 필요성이 없어
일단 query client queries,mutations 의 retry 옵션 false로 변경