### PR TITLE
요약 재요청 기능 구현

### DIFF
--- a/components/post/url-text-field.tsx
+++ b/components/post/url-text-field.tsx
@@ -20,15 +20,13 @@ import {
   SummaryToneLabels,
 } from '@/constants/SummaryOptionLabels';
 import { useCreatePostMutation } from '@/lib/service/post/use-post-service';
+import { useRouter } from 'next/navigation';
+import { useSummaryStore } from '@/store/useSummaryStore';
 
 const URLTextField = () => {
-  const [url, setUrl] = useState('');
-  const [options, setOptions] = useState<SummaryOptions>({
-    level: 'base',
-    tone: 'casual',
-    language: 'kr',
-  });
-  const [dialogMessage, setDialogMessage] = useState<string | null>(null); // 다이얼로그 메시지 상태
+  const { url, setUrl, options, setOptions } = useSummaryStore();
+  const [dialogMessage, setDialogMessage] = useState<string | null>(null);
+  const router = useRouter();
 
   const handleConfirm = (options: SummaryOptions) => {
     setOptions(options);
@@ -52,6 +50,9 @@ const URLTextField = () => {
           setDialogMessage(
             '요약을 생성하는 데 문제가 발생했습니다.\n URL을 다시 확인하거나 잠시 후 다시 시도해 주세요.',
           );
+        },
+        onSuccess: ({ postId }) => {
+          router.push(`/result/${postId}`);
         },
       },
     );

--- a/components/summary/feadback-box.tsx
+++ b/components/summary/feadback-box.tsx
@@ -1,9 +1,26 @@
+'use client';
+
+import OptionDialog from '@/components/summary/option-dialog';
 import Button from '@/components/ui/Button';
+import { DialogTrigger } from '@/components/ui/Dialog';
+import { useCreatePostMutation } from '@/lib/service/post/use-post-service';
 import { cn } from '@/lib/utils';
+import { useSummaryStore } from '@/store/useSummaryStore';
 import { typography } from '@/styles/typography';
+import { SummaryOptions } from '@/types/summary-types';
+import { Dialog } from '@radix-ui/react-dialog';
 import { FunctionComponent } from 'react';
 
 const FeedbackBox: FunctionComponent = () => {
+  const { url, options, setOptions } = useSummaryStore();
+  const { mutate } = useCreatePostMutation();
+  const handleConfirm = (newOptions: SummaryOptions) => {
+    setOptions(options);
+    mutate({
+      url,
+      options: newOptions,
+    });
+  };
   return (
     <div>
       <div
@@ -13,9 +30,14 @@ const FeedbackBox: FunctionComponent = () => {
         )}
       >
         요약이 마음에 안드시나요?
-        <Button type="button" variant="outlined" size="lg">
-          재요약하기
-        </Button>
+        <Dialog>
+          <DialogTrigger asChild>
+            <Button type="button" variant="outlined" size="lg">
+              재요약하기
+            </Button>
+          </DialogTrigger>
+          <OptionDialog onConfirm={handleConfirm} initialOptions={options} />
+        </Dialog>
       </div>
     </div>
   );

--- a/components/summary/option-dialog.tsx
+++ b/components/summary/option-dialog.tsx
@@ -1,3 +1,4 @@
+'use client';
 import Button from '@/components/ui/Button';
 import {
   DialogClose,
@@ -22,16 +23,28 @@ import { SummaryOptions } from '@/types/summary-types';
 import { ChangeEvent, FunctionComponent, useId, useState } from 'react';
 
 interface OptionDialogProps {
+  initialOptions?: SummaryOptions;
   onConfirm: (options: SummaryOptions) => void;
 }
-const OptionDialog: FunctionComponent<OptionDialogProps> = ({ onConfirm }) => {
+const OptionDialog: FunctionComponent<OptionDialogProps> = ({
+  onConfirm,
+  initialOptions = {
+    language: 'kr',
+    level: 'base',
+    tone: 'casual',
+  },
+}) => {
   const levelRadioGroupId = useId();
   const toneRadioGroupId = useId();
   const languageRadioGroupId = useId();
 
-  const [level, setLevel] = useState<SummaryOptions['level']>('base');
-  const [tone, setTone] = useState<SummaryOptions['tone']>('casual');
-  const [language, setLanguage] = useState<SummaryOptions['language']>('kr');
+  const [level, setLevel] = useState<SummaryOptions['level']>(
+    initialOptions.level,
+  );
+  const [tone, setTone] = useState<SummaryOptions['tone']>(initialOptions.tone);
+  const [language, setLanguage] = useState<SummaryOptions['language']>(
+    initialOptions.language,
+  );
   const [keyword, setKeyword] = useState<string>('');
 
   const handleConfirmButtonClick = () => {
@@ -155,6 +168,7 @@ const OptionDialog: FunctionComponent<OptionDialogProps> = ({ onConfirm }) => {
       <DialogFooter className="p-0">
         <DialogClose asChild>
           <Button
+            size="lg"
             type="button"
             variant="filled"
             onClick={handleConfirmButtonClick}

--- a/lib/service/post/use-post-service.ts
+++ b/lib/service/post/use-post-service.ts
@@ -24,14 +24,15 @@ import {
   deletePost,
   updateMemo,
 } from '@/lib/service/post/post-service';
-import { useRouter } from 'next/navigation';
 
 export function useCreatePostMutation() {
-  const router = useRouter();
+  const queryClient = useQueryClient();
   return useMutation<CreatePostResponse, Error, CreatePostRequest>({
     mutationFn: createPost,
-    onSuccess: ({ postId }) => {
-      router.push(`/result/${postId}`);
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: postQuerys.detail._def,
+      });
     },
   });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,8 @@
         "tailwind-merge": "^2.5.2",
         "tailwindcss-animate": "^1.0.7",
         "usehooks-ts": "^3.1.0",
-        "zod": "^3.23.8"
+        "zod": "^3.23.8",
+        "zustand": "^5.0.0-rc.2"
       },
       "devDependencies": {
         "@chromatic-com/storybook": "^1.9.0",
@@ -22130,6 +22131,35 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.0-rc.2.tgz",
+      "integrity": "sha512-o2Nwuvnk8vQBX7CcHL8WfFkZNJdxB/VKeWw0tNglw8p4cypsZ3tRT7rTRTDNeUPFS0qaMBRSKe+fVwL5xpcE3A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
     "usehooks-ts": "^3.1.0",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "zustand": "^5.0.0-rc.2"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^1.9.0",

--- a/store/useSummaryStore.ts
+++ b/store/useSummaryStore.ts
@@ -1,0 +1,20 @@
+import { create } from 'zustand';
+import { SummaryOptions } from '@/types/summary-types';
+
+interface SummaryState {
+  url: string;
+  options: SummaryOptions;
+  setUrl: (url: string) => void;
+  setOptions: (options: SummaryOptions) => void;
+}
+
+export const useSummaryStore = create<SummaryState>((set) => ({
+  url: '',
+  options: {
+    level: 'base',
+    tone: 'casual',
+    language: 'kr',
+  },
+  setUrl: (url) => set(() => ({ url })),
+  setOptions: (options) => set(() => ({ options })),
+}));


### PR DESCRIPTION
- 홈에서 요약 요청 시 zustand store 에 url, options state update
- zustand store 를 통해 url, options 참조하여 옵션 다이얼로그에 반영되도록 하고 요약 재요청 시 update
- 재요약 요청 성공 시 쿼리 초기화
Fixes #75 