### PR TITLE
refactor: 메모 textfield 에 react-hook-form 및 Zod 유효성 검사 추가

### DIFF
--- a/components/post/memo-text-field.tsx
+++ b/components/post/memo-text-field.tsx
@@ -1,10 +1,17 @@
 'use client';
 import Button from '@/components/ui/Button';
 import TextField from '@/components/ui/TextField';
+import {
+  POST_MEMO_MAX_LENGTH,
+  postSchema,
+  PostSchema,
+} from '@/lib/service/post/constraints';
 import { useUpdateMemo } from '@/lib/service/post/use-post-service';
 import { cn } from '@/lib/utils';
 import { typography } from '@/styles/typography';
-import React, { ChangeEvent, KeyboardEvent, useRef, useState } from 'react';
+import { zodResolver } from '@hookform/resolvers/zod';
+import React, { useRef, useState } from 'react';
+import { useForm } from 'react-hook-form';
 
 interface MemoTextFieldProps {
   postId: string;
@@ -17,23 +24,28 @@ const MemoTextField = ({
   initialMemo = '',
   createdAt,
 }: MemoTextFieldProps) => {
-  const [memo, setMemo] = useState(initialMemo);
   const [isEditing, setIsEditing] = useState(false);
   const { mutate: updateMemoMutate } = useUpdateMemo();
+  const maxLength = POST_MEMO_MAX_LENGTH;
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors },
+  } = useForm<PostSchema>({
+    resolver: zodResolver(postSchema),
+    defaultValues: {
+      memo: initialMemo,
+    },
+  });
+  const memo = watch('memo');
+  const textCounter = `${memo.length} / ${maxLength}`;
 
   const updateMemo = () => {
-    setIsEditing(false);
-    updateMemoMutate({ postId, content: memo });
-  };
-
-  const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
-    setMemo(e.target.value);
-  };
-
-  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key === 'Enter') {
-      updateMemo();
-    }
+    updateMemoMutate(
+      { postId, content: memo },
+      { onSuccess: () => setIsEditing(false) },
+    );
   };
 
   const textFieldRef = useRef<HTMLTextAreaElement>(null);
@@ -53,39 +65,41 @@ const MemoTextField = ({
       ? '메모 수정'
       : '메모 등록';
 
+  const bottomText = isEditing ? textCounter : createdAt;
+
   return (
-    <div className="mt-7">
+    <form className="mt-7" onSubmit={handleSubmit(updateMemo)}>
       <TextField
         placeholder="메모를 남겨보세요 :>"
-        onChange={handleChange}
-        onKeyDown={handleKeyDown}
-        value={memo}
         className="w-full"
-        ref={textFieldRef}
         readOnly={!isEditing}
+        {...register('memo', {
+          maxLength,
+        })}
       >
         <div className="flex w-full items-end justify-between">
-          {createdAt && (
-            <span
-              className={cn(
-                typography({ scale: 'body-4' }),
-                'flex-shrink-0 text-gray-800',
-              )}
-            >
-              {createdAt}
-            </span>
-          )}
+          <span
+            className={cn(
+              typography({ scale: 'body-4' }),
+              'flex-shrink-0',
+              errors.memo !== undefined ? 'text-error-400' : 'text-gray-800',
+            )}
+          >
+            {bottomText}
+          </span>
           <Button
             variant="rounded"
             size="lg"
+            type="submit"
             onClick={handleClick}
             className="round-13"
+            disabled={Boolean(errors.memo)}
           >
             {buttonLabel}
           </Button>
         </div>
       </TextField>
-    </div>
+    </form>
   );
 };
 

--- a/components/post/memo-text-field.tsx
+++ b/components/post/memo-text-field.tsx
@@ -38,7 +38,7 @@ const MemoTextField = ({
       memo: initialMemo,
     },
   });
-  const memo = watch('memo');
+  const memo = watch('memo', '');
   const textCounter = `${memo.length} / ${maxLength}`;
 
   const updateMemo = () => {

--- a/components/post/post-title-input.tsx
+++ b/components/post/post-title-input.tsx
@@ -1,10 +1,9 @@
+import { PostSchema } from '@/lib/service/post/constraints';
 import { FunctionComponent } from 'react';
 import { UseFormRegister } from 'react-hook-form';
 
 interface PostTitleInputProps {
-  register: UseFormRegister<{
-    title: string;
-  }>;
+  register: UseFormRegister<PostSchema>;
 }
 
 const PostTitleInput: FunctionComponent<PostTitleInputProps> = ({
@@ -14,7 +13,7 @@ const PostTitleInput: FunctionComponent<PostTitleInputProps> = ({
     <div className="flex flex-shrink-0 items-center justify-center p-4">
       <div className="flex flex-col">
         <input
-          {...register('title')}
+          {...register('memo')}
           placeholder="제목을 입력하세요"
           className="flex-1 bg-transparent text-center text-3xl font-semibold"
         />

--- a/lib/service/post/constraints.ts
+++ b/lib/service/post/constraints.ts
@@ -4,12 +4,15 @@ const POST_TITLE_MAX_LENGTH: number = 100;
 const POST_TITLE_MAX_LENGTH_ERROR: string = '제목을 100자 이내로 입력해주세요.';
 const POST_TITLE_MIN_LENGTH: number = 1;
 const POST_TITLE_MIN_LENGTH_ERROR: string = '제목을 입력하세요.';
+const POST_MEMO_MIN_LENGTH: number = 0;
+export const POST_MEMO_MAX_LENGTH: number = 1000;
 
 export const postSchema = z.object({
   title: z
     .string()
     .min(POST_TITLE_MIN_LENGTH, POST_TITLE_MIN_LENGTH_ERROR)
     .max(POST_TITLE_MAX_LENGTH, POST_TITLE_MAX_LENGTH_ERROR),
+  memo: z.string().min(POST_MEMO_MIN_LENGTH).max(POST_MEMO_MAX_LENGTH),
 });
 
 export type PostSchema = z.infer<typeof postSchema>;


### PR DESCRIPTION
- 메모 입력 필드에 react-hook-form 적용
- Zod를 사용하여 메모 최대 2000자 유효성 검사 추가
- 수정 및 등록 버튼 클릭 시 메모 업데이트 처리
- 입력된 메모의 글자 수를 실시간으로 추적하고, 글자 수 카운터 표시
- 유효성 검사 실패 시 버튼 비활성화, 글자 수 카운터 경고색 표시

Fixes #91