### PR TITLE
fix: 게시글 삭제 후 아카이브로 이동

### DIFF
--- a/components/post/delete-post-button.tsx
+++ b/components/post/delete-post-button.tsx
@@ -14,7 +14,7 @@ import Link from 'next/link';
 import React, { useState } from 'react';
 
 interface PostDeleteButtonProps {
-  archiveId: string;
+  archiveId?: number;
   postId: string;
 }
 
@@ -68,7 +68,13 @@ const PostDeleteButton = ({ archiveId, postId }: PostDeleteButtonProps) => {
             요약본이 삭제되었습니다.
           </DialogDescription>
           <DialogFooter>
-            <Link href={`/archive?id=${archiveId}`}>
+            <Link
+              href={
+                archiveId !== undefined
+                  ? '/archive'
+                  : `/archive?id=${archiveId}`
+              }
+            >
               <Button size="lg" onClick={handleAcceptButtonClick}>
                 확인
               </Button>

--- a/components/post/post-detail.tsx
+++ b/components/post/post-detail.tsx
@@ -55,10 +55,7 @@ const PostDetail: FunctionComponent<PostDetailProps> = ({
           >
             수정
           </Link>
-          {/**
-           * @todo fetchPost 응답으로 archiveId 받아 props 전달 필요
-           */}
-          <DeletePostButton postId={id} archiveId={''} />
+          <DeletePostButton postId={id} archiveId={archiveId} />
         </div>
       )}
       <a


### PR DESCRIPTION
게시글 삭제 후 원래 게시글이 속한 아카이브가 있다면 해당 아카이브로, 없다면 전체로 이동하도록 하였습니다