### PR TITLE
에디터 버그 수정

### DIFF
--- a/components/editor/heading-toggles.tsx
+++ b/components/editor/heading-toggles.tsx
@@ -1,5 +1,10 @@
 import { FunctionComponent } from 'react';
-import { usePublisher, convertSelectionToNode$ } from '@mdxeditor/editor';
+import {
+  usePublisher,
+  convertSelectionToNode$,
+  currentBlockType$,
+  useCellValues,
+} from '@mdxeditor/editor';
 import { $createHeadingNode, type HeadingTagType } from '@lexical/rich-text';
 import { $createParagraphNode } from 'lexical';
 import Heading1Icon from '@/assets/heading-1.svg';
@@ -9,6 +14,7 @@ import Heading3Icon from '@/assets/heading-3.svg';
 import { ToolbarToggleGroup, ToolbarToggleItem } from '@/components/ui/Toolbar';
 
 const HeadingToggles: FunctionComponent = () => {
+  const [currentBlockType] = useCellValues(currentBlockType$);
   const convertSelectionToNode = usePublisher(convertSelectionToNode$);
   const handleChange = (blockType: HeadingTagType) => {
     if (blockType.startsWith('h')) {
@@ -20,6 +26,7 @@ const HeadingToggles: FunctionComponent = () => {
   return (
     <ToolbarToggleGroup
       type="single"
+      value={currentBlockType}
       onValueChange={handleChange}
       className="flex gap-1"
     >

--- a/components/post/memo-text-field.tsx
+++ b/components/post/memo-text-field.tsx
@@ -2,9 +2,9 @@
 import Button from '@/components/ui/Button';
 import TextField from '@/components/ui/TextField';
 import {
+  memoSchema,
+  MemoSchema,
   POST_MEMO_MAX_LENGTH,
-  postSchema,
-  PostSchema,
 } from '@/lib/service/post/constraints';
 import { useUpdateMemo } from '@/lib/service/post/use-post-service';
 import { cn } from '@/lib/utils';
@@ -32,8 +32,8 @@ const MemoTextField = ({
     handleSubmit,
     watch,
     formState: { errors },
-  } = useForm<PostSchema>({
-    resolver: zodResolver(postSchema),
+  } = useForm<MemoSchema>({
+    resolver: zodResolver(memoSchema),
     defaultValues: {
       memo: initialMemo || '',
     },

--- a/components/post/memo-text-field.tsx
+++ b/components/post/memo-text-field.tsx
@@ -37,6 +37,7 @@ const MemoTextField = ({
     defaultValues: {
       memo: initialMemo || '',
     },
+    mode: 'onChange',
   });
   const memo = watch('memo');
   const textCounter = `${memo.length} / ${maxLength}`;
@@ -50,9 +51,9 @@ const MemoTextField = ({
 
   const textFieldRef = useRef<HTMLTextAreaElement>(null);
 
-  const handleClick = () => {
+  const handleClick = async () => {
     if (isEditing) {
-      updateMemo();
+      await handleSubmit(updateMemo)();
     } else {
       setIsEditing(true);
       textFieldRef.current?.focus();
@@ -90,7 +91,7 @@ const MemoTextField = ({
           <Button
             variant="rounded"
             size="lg"
-            type="submit"
+            type="button"
             onClick={handleClick}
             className="round-13"
             disabled={Boolean(errors.memo)}

--- a/components/post/post-editor.tsx
+++ b/components/post/post-editor.tsx
@@ -40,7 +40,7 @@ interface PostEditorProps {
 
 const PostEditor: FunctionComponent<PostEditorProps> = ({ id, status }) => {
   const {
-    data: { content, title, tagList, archiveId },
+    data: { content, title, tagList, archiveId, memoContent },
   } = usePostDetail({ id, status });
   const { mutate: updatePostMutate } = useUpdatePostMutation();
   const tagListRef = useRef<{ getTagList: () => string[] }>(null);
@@ -86,8 +86,8 @@ const PostEditor: FunctionComponent<PostEditorProps> = ({ id, status }) => {
           title: getValues('title'),
           content: editorRef.current?.getMarkdown().trim() ?? '',
           tagList: tagListRef.current?.getTagList() ?? [],
-          memo: null,
-          archiveId: archiveId === -1 ? null : archiveId,
+          memo: memoContent,
+          archiveId: archiveId === -1 ? undefined : archiveId,
         },
       },
       {

--- a/components/post/post-editor.tsx
+++ b/components/post/post-editor.tsx
@@ -22,9 +22,13 @@ import PostTags from '@/components/post/post-tags';
 import { Dialog } from '@/components/ui/Dialog';
 import SavePostDialog from '@/components/post/post-save-dialog';
 import { useRouter } from 'next/navigation';
-import { FieldErrors, useForm } from 'react-hook-form';
+import { Controller, FieldErrors, useForm } from 'react-hook-form';
 import { useToast } from '@/components/hooks/use-toast';
-import { PostSchema, postSchema } from '@/lib/service/post/constraints';
+import {
+  POST_CONTENT_MAX_LENGTH,
+  PostSchema,
+  postSchema,
+} from '@/lib/service/post/constraints';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useUserProfile } from '@/lib/service/user/use-user-service';
 import LoginDialog from '@/components/auth/login-dialog';
@@ -44,22 +48,27 @@ const PostEditor: FunctionComponent<PostEditorProps> = ({ id, status }) => {
 
   const editorRef = useRef<MDXEditorMethods>(null);
 
-  const [textLength, setTextLength] = useState(content.trim().length);
-
   const [fold, setFold] = useState(false);
 
   const { toast, dismiss } = useToast();
   const {
+    watch,
+    control,
     register,
     getValues,
+    setFocus,
     handleSubmit,
     formState: { errors },
   } = useForm<PostSchema>({
     resolver: zodResolver(postSchema),
     defaultValues: {
       title: title,
+      content: content,
     },
+    mode: 'onChange',
   });
+
+  const textLength = watch('content').length;
 
   useEffect(() => {
     if (!errors.title) {
@@ -98,10 +107,6 @@ const PostEditor: FunctionComponent<PostEditorProps> = ({ id, status }) => {
     );
   };
 
-  const handleChange = (value: string) => {
-    setTextLength(value.trim().length);
-  };
-
   const toggleFold = () => {
     setFold(!fold);
   };
@@ -114,6 +119,14 @@ const PostEditor: FunctionComponent<PostEditorProps> = ({ id, status }) => {
         description: error.title.message?.toString(),
         variant: 'destructive',
       });
+      setFocus('title');
+    }
+    if (error.content) {
+      toast({
+        description: error.content.message?.toString(),
+        variant: 'destructive',
+      });
+      setFocus('content');
     }
   };
 
@@ -151,15 +164,26 @@ const PostEditor: FunctionComponent<PostEditorProps> = ({ id, status }) => {
               ref={tagListRef}
               className="mb-4 ml-10"
             />
-            <Editor
-              markdown={content}
-              ref={editorRef}
-              onChange={handleChange}
-              className="flex flex-grow basis-0 flex-col px-4"
+            <Controller
+              name="content"
+              control={control}
+              defaultValue={content}
+              render={({ field: { onChange, value } }) => (
+                <Editor
+                  markdown={value}
+                  ref={editorRef}
+                  onChange={onChange}
+                  className="flex flex-grow basis-0 flex-col px-4"
+                />
+              )}
             />
             <div className="flex-shrink-0 bg-white p-5">
               <div className="flex flex-col items-end gap-4">
-                <span className="text-gray-600">{`${textLength}/5000`}</span>
+                <span
+                  className={
+                    errors.content?.message ? 'text-error-400' : 'text-gray-600'
+                  }
+                >{`${textLength}/${POST_CONTENT_MAX_LENGTH}`}</span>
                 <Button size="lg" type="submit" variant="filled">
                   저장하기
                 </Button>

--- a/components/post/post-tags.tsx
+++ b/components/post/post-tags.tsx
@@ -44,6 +44,11 @@ const PostTags = forwardRef<{ getTagList: () => string[] }, PostTagsProps>(
         addNewTag();
       }
     };
+    const preventDefault = (e: KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+      }
+    };
 
     useImperativeHandle(ref, () => ({
       getTagList: () => tagList,
@@ -62,6 +67,7 @@ const PostTags = forwardRef<{ getTagList: () => string[] }, PostTagsProps>(
             placeholder="태그를 입력하세요"
             value={tag}
             onKeyUp={handleKeyUp}
+            onKeyDown={preventDefault}
             onChange={handleTagChange}
             onBlur={addNewTag}
             className="px-2 py-1"

--- a/components/post/post-title-input.tsx
+++ b/components/post/post-title-input.tsx
@@ -13,7 +13,7 @@ const PostTitleInput: FunctionComponent<PostTitleInputProps> = ({
     <div className="flex flex-shrink-0 items-center justify-center p-4">
       <div className="flex flex-col">
         <input
-          {...register('memo')}
+          {...register('title')}
           placeholder="제목을 입력하세요"
           className="flex-1 bg-transparent text-center text-3xl font-semibold"
         />

--- a/lib/service/post/constraints.ts
+++ b/lib/service/post/constraints.ts
@@ -12,6 +12,10 @@ export const POST_CONTENT_MAX_LENGTH: number = 5000;
 const POST_MEMO_MIN_LENGTH: number = 0;
 export const POST_MEMO_MAX_LENGTH: number = 1000;
 
+export const memoSchema = z.object({
+  memo: z.string().min(POST_MEMO_MIN_LENGTH).max(POST_MEMO_MAX_LENGTH),
+});
+
 export const postSchema = z.object({
   title: z
     .string()
@@ -21,7 +25,7 @@ export const postSchema = z.object({
     .string()
     .min(POST_CONTENT_MIN_LENGTH, POST_CONTENT_MIN_LENGTH_ERROR)
     .max(POST_CONTENT_MAX_LENGTH, POST_CONTENT_MAX_LENGTH_ERROR),
-  memo: z.string().min(POST_MEMO_MIN_LENGTH).max(POST_MEMO_MAX_LENGTH),
 });
 
 export type PostSchema = z.infer<typeof postSchema>;
+export type MemoSchema = z.infer<typeof memoSchema>;

--- a/lib/service/post/constraints.ts
+++ b/lib/service/post/constraints.ts
@@ -4,6 +4,11 @@ const POST_TITLE_MAX_LENGTH: number = 100;
 const POST_TITLE_MAX_LENGTH_ERROR: string = '제목을 100자 이내로 입력해주세요.';
 const POST_TITLE_MIN_LENGTH: number = 1;
 const POST_TITLE_MIN_LENGTH_ERROR: string = '제목을 입력하세요.';
+const POST_CONTENT_MIN_LENGTH: number = 1;
+const POST_CONTENT_MIN_LENGTH_ERROR: string = '내용을 입력하세요.';
+const POST_CONTENT_MAX_LENGTH_ERROR: string =
+  '5000자를 초과하여 입력할 수 없습니다.';
+export const POST_CONTENT_MAX_LENGTH: number = 5000;
 const POST_MEMO_MIN_LENGTH: number = 0;
 export const POST_MEMO_MAX_LENGTH: number = 1000;
 
@@ -12,6 +17,10 @@ export const postSchema = z.object({
     .string()
     .min(POST_TITLE_MIN_LENGTH, POST_TITLE_MIN_LENGTH_ERROR)
     .max(POST_TITLE_MAX_LENGTH, POST_TITLE_MAX_LENGTH_ERROR),
+  content: z
+    .string()
+    .min(POST_CONTENT_MIN_LENGTH, POST_CONTENT_MIN_LENGTH_ERROR)
+    .max(POST_CONTENT_MAX_LENGTH, POST_CONTENT_MAX_LENGTH_ERROR),
   memo: z.string().min(POST_MEMO_MIN_LENGTH).max(POST_MEMO_MAX_LENGTH),
 });
 

--- a/lib/service/post/constraints.ts
+++ b/lib/service/post/constraints.ts
@@ -10,7 +10,7 @@ const POST_CONTENT_MAX_LENGTH_ERROR: string =
   '5000자를 초과하여 입력할 수 없습니다.';
 export const POST_CONTENT_MAX_LENGTH: number = 5000;
 const POST_MEMO_MIN_LENGTH: number = 0;
-export const POST_MEMO_MAX_LENGTH: number = 1000;
+export const POST_MEMO_MAX_LENGTH: number = 2000;
 
 export const memoSchema = z.object({
   memo: z.string().min(POST_MEMO_MIN_LENGTH).max(POST_MEMO_MAX_LENGTH),

--- a/types/post-types.ts
+++ b/types/post-types.ts
@@ -34,8 +34,8 @@ export interface UpdatePostBody {
   content: string;
   title: string;
   tagList: string[];
-  archiveId: number | null;
-  memo: string | null;
+  archiveId?: number;
+  memo?: string;
 }
 
 export interface FetchPostsRequest {


### PR DESCRIPTION
### 포스트 내용 유효성 검사 추가 Fixes #42 
  - react-hook-form의 Controller 컴포넌트로 content 필드를 제어하도록 수정
  - title, content 유효성 검사 시 toast 메시지와 focus 설정 추가
  - content의 길이를 실시간으로 감시하여 표시되도록 watch 사용
  - 에디터 내용 변경 시 textLength 업데이트 반영

### 포스트 제목이 반영되지 않는 이슈 수정 Fixes #100 
  - 잘못된 필드명 'memo'를 'title'로 수정

### 메모 등록 시 바로 수정 완료로 바뀌는 버그 수정
- Button type 을 submit 에서 button 으로 변경
- click event handler 에서 handleSubmit 호출
- 2000자 넘는 순간 에러가 발생해야하기 때문에 mode 를 onChange 로 변경

### 태그 등록 되지 않는 이슈 수정
- 게시물 수정 영역을 form 으로 변경하여 발생한 side effect
- keydown 이벤트에서 e.preventDefault 호출하여 폼 제출 막음

### 툴바 Heading 토글 그룹에서 블록 타입 selected 표시
- useCellValues로 currentBlockType 값 구독
- ToolbarToggleGroup 에 value 전달